### PR TITLE
Player states: Add getter methods for direction to make a test suite for PlayerStateIdle transitions

### DIFF
--- a/Assets/Scripts/Link/PlayerController.cs
+++ b/Assets/Scripts/Link/PlayerController.cs
@@ -68,6 +68,11 @@ public class PlayerController : MonoBehaviour
         state.advanceState();
     }
 
+    public PlayerState GetState()
+    {
+        return this.state;
+    }
+
     public void setState(PlayerState s)
     {
         this.state = s;

--- a/Assets/Scripts/Link/PlayerState.cs
+++ b/Assets/Scripts/Link/PlayerState.cs
@@ -14,4 +14,6 @@ public interface PlayerState
     public void handleIdle();
 
     public void advanceState();
+
+    public PlayerDirection GetDirection();
 }

--- a/Assets/Scripts/Link/PlayerStates/PlayerStateAttack.cs
+++ b/Assets/Scripts/Link/PlayerStates/PlayerStateAttack.cs
@@ -86,4 +86,9 @@ public class PlayerStateAttack : PlayerState
     {
         // cannot idle while already attacking
     }
+
+    public PlayerDirection GetDirection()
+    {
+        return this.direction;
+    }
 }

--- a/Assets/Scripts/Link/PlayerStates/PlayerStateIdle.cs
+++ b/Assets/Scripts/Link/PlayerStates/PlayerStateIdle.cs
@@ -69,4 +69,9 @@ public class PlayerStateIdle : PlayerState
     {
         // already idle
     }
+
+    public PlayerDirection GetDirection()
+    {
+        return this.direction;
+    }
 }

--- a/Assets/Scripts/Link/PlayerStates/PlayerStateWalk.cs
+++ b/Assets/Scripts/Link/PlayerStates/PlayerStateWalk.cs
@@ -69,4 +69,9 @@ public class PlayerStateWalk : PlayerState
         player.ResetAnimatorTriggers();
         player.setState(new PlayerStateIdle(player, this.direction));
     }
+
+    public PlayerDirection GetDirection()
+    {
+        return this.direction;
+    }
 }

--- a/Assets/Scripts/Scripts.asmdef
+++ b/Assets/Scripts/Scripts.asmdef
@@ -1,0 +1,3 @@
+{
+	"name": "Scripts"
+}

--- a/Assets/Scripts/Scripts.asmdef.meta
+++ b/Assets/Scripts/Scripts.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5e21a4ea3c85742a78c14f83636d99cc
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests.meta
+++ b/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b5678c9b1fe9c442b8cd4dd0fc171edb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode.meta
+++ b/Assets/Tests/EditMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cad921f7b650c43aa88a49391f4c5a6b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/EditMode.asmdef
+++ b/Assets/Tests/EditMode/EditMode.asmdef
@@ -1,0 +1,24 @@
+{
+    "name": "EditMode",
+    "rootNamespace": "",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "Scripts"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Tests/EditMode/EditMode.asmdef.meta
+++ b/Assets/Tests/EditMode/EditMode.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ee559a2511c2a4db98722dcd6ec75b51
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/PlayerStateIdleTests.cs
+++ b/Assets/Tests/EditMode/PlayerStateIdleTests.cs
@@ -1,0 +1,92 @@
+// Joshua Peisach
+
+// This test suite tests the handling of changing player directions and states, primarily in context of a PlayerStateIdle.
+// In order to test the suite, I added a test for default player state and direction, all four directions, consecutive
+// inputs of the same key, and two directly opposite dirrections to ensure the player is facing the way it should.
+// While at this point, I also ensured that the state was moved to PlayerStateWalk on input, otherwise remaining at
+// PlayerStateIdle. The tests shouldn't be brittle, it's really just creating a new object and updating the PlayerController
+// accordingly. While a test double could fit this better, as of writing the PlayerStates were not written for dependency injection,
+// so unless we can't find a place to make a test suite using test doubles, this will be a simple recreation of the PlayerController,
+// just with the necessary objects.
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+public class PlayerStateIdleTests
+{
+    private PlayerController player;
+
+    [SetUp]
+    public void Setup()
+    {
+        player = new GameObject().AddComponent<PlayerController>();
+        player.animator = player.gameObject.AddComponent<Animator>();
+
+        player.setState(new PlayerStateIdle(player, PlayerDirection.UP));
+    }
+
+    [Test]
+    public void PlayerDirection_UpIdleByDefault()
+    {
+        Assert.AreEqual(PlayerDirection.UP, player.GetState().GetDirection());
+        Assert.That(player.GetState(), Is.TypeOf<PlayerStateIdle>());
+    }
+
+    [Test]
+    public void PlayerDirection_LeftWalkOnInputLeft()
+    {
+        player.GetState().handleLeft();
+
+        Assert.AreEqual(PlayerDirection.LEFT, player.GetState().GetDirection());
+        Assert.That(player.GetState(), Is.TypeOf<PlayerStateWalk>());
+    }
+
+    [Test]
+    public void PlayerDirection_RightWalkOnInputRight()
+    {
+        player.GetState().handleRight();
+
+        Assert.AreEqual(PlayerDirection.RIGHT, player.GetState().GetDirection());
+        Assert.That(player.GetState(), Is.TypeOf<PlayerStateWalk>());
+    }
+
+    [Test]
+    public void PlayerDirection_UpWalkOnInputUp()
+    {
+        player.GetState().handleUp();
+
+        Assert.AreEqual(PlayerDirection.UP, player.GetState().GetDirection());
+        Assert.That(player.GetState(), Is.TypeOf<PlayerStateWalk>());
+    }
+
+    [Test]
+    public void PlayerDirection_DownWalkOnInputDown()
+    {
+        player.GetState().handleDown();
+
+        Assert.AreEqual(PlayerDirection.DOWN, player.GetState().GetDirection());
+        Assert.That(player.GetState(), Is.TypeOf<PlayerStateWalk>());
+    }
+
+    [Test]
+    public void PlayerDirection_DownWalkOnConsecutiveInputDown()
+    {
+        player.GetState().handleDown();
+        player.GetState().handleDown();
+
+        Assert.AreEqual(PlayerDirection.DOWN, player.GetState().GetDirection());
+        Assert.That(player.GetState(), Is.TypeOf<PlayerStateWalk>());
+    }
+
+    [Test]
+    public void PlayerDirection_UpWalkOnInputDownUp()
+    {
+        player.GetState().handleDown();
+        player.GetState().handleUp();
+
+        Assert.AreEqual(PlayerDirection.UP, player.GetState().GetDirection());
+        Assert.That(player.GetState(), Is.TypeOf<PlayerStateWalk>());
+    }
+}

--- a/Assets/Tests/EditMode/PlayerStateIdleTests.cs.meta
+++ b/Assets/Tests/EditMode/PlayerStateIdleTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 75de72f6ec4d64680b8c7890d779aded
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Nothing too crazy - just needed to make sure we can get the PlayerState from PlayerController and the PlayerDirection from each PlayerState.